### PR TITLE
Update Confluence version to 6.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blacklabelops/java:jre8
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG CONFLUENCE_VERSION=6.0.4
+ARG CONFLUENCE_VERSION=6.1.2
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Confluence | 6.0.4 | 6.0.4, latest | [Dockerfile](https://github.com/blacklabelops/confluence/blob/master/Dockerfile) |
+| Confluence | 6.1.2 | 6.1.2, latest | [Dockerfile](https://github.com/blacklabelops/confluence/blob/master/Dockerfile) |
 
 ## Related Images
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,4 +3,4 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export CONFLUENCE_VERSION=6.0.4
+export CONFLUENCE_VERSION=6.1.2


### PR DESCRIPTION
Only incremented confluence version to current release. Based upon confluence release note, this _might_ fix #2 (see https://confluence.atlassian.com/doc/confluence-6-1-release-notes-872277785.html#Confluence6.1ReleaseNotes-Collaborativeeditingkeepsgettingbetter)
I tested running and setup of confluence instance, but without reverse-proxy.