### PR TITLE
Keep curl package for health-checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN export CONTAINER_USER=confluence                &&  \
     curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && \
     chmod +x /bin/tini && \
     # Remove obsolete packages and cleanup
-    apk del wget curl && \
+    apk del wget && \
     # Clean caches and tmps
     rm -rf /var/cache/apk/*                         &&  \
     rm -rf /tmp/*                                   &&  \


### PR DESCRIPTION
If using docker-compose.yml healthcheck, the normal is to use curl to check app health.

See: https://docs.docker.com/compose/compose-file/#healthcheck