### PR TITLE
Add missing fonts for CAPTCHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,11 @@ RUN export CONTAINER_USER=confluence                &&  \
       tar                                               \
       xmlstarlet                                        \
       msttcorefonts-installer                           \
+      ttf-dejavu					\
       fontconfig                                        \
+      ghostscript					\
       graphviz                                          \
+      motif						\
       wget                                          &&  \
     # Installing true type fonts
     update-ms-fonts                                 && \


### PR DESCRIPTION
Add required packages for full CAPTCHA support [per documentation](https://confluence.atlassian.com/confkb/confluence-ui-shows-garbled-or-corrupt-text-on-captcha-macros-and-or-diagrams-due-to-missing-fonts-938027858.html).