### PR TITLE
Confluence 6.6.0 -> 6.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blacklabelops/java:server-jre.8
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG CONFLUENCE_VERSION=6.6.0
+ARG CONFLUENCE_VERSION=6.6.1
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Confluence | 6.6.0 | 6.6.0, latest | [Dockerfile](https://github.com/blacklabelops/confluence/blob/master/Dockerfile) |
+| Confluence | 6.6.1 | 6.6.1, latest | [Dockerfile](https://github.com/blacklabelops/confluence/blob/master/Dockerfile) |
 
 # Related Images
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,4 +3,4 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export CONFLUENCE_VERSION=6.6.0
+export CONFLUENCE_VERSION=6.6.1


### PR DESCRIPTION
Update of Confluence to newest version 6.6.1.

https://confluence.atlassian.com/doc/issues-resolved-in-6-6-1-942860356.html